### PR TITLE
Updating to recent versions, fixing path handling problem, adding comments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ scala:
   - 2.11.7
 script:
   - "sbt ++$TRAVIS_SCALA_VERSION test"
+jdk:
+  - oraclejdk8
+  - oraclejdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: scala
 scala:
   - 2.11.7
-script:
-  - "sbt ++$TRAVIS_SCALA_VERSION test"
 jdk:
   - oraclejdk8
-  - oraclejdk7
+script:
+  - "sbt ++$TRAVIS_SCALA_VERSION test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: scala
 scala:
-  - 2.10.3
+  - 2.11.7
 script:
   - "sbt ++$TRAVIS_SCALA_VERSION test"

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ name:="spray-cookies"
 
 version:="0.1-SNAPSHOT"
 
-scalaVersion:="2.10.3"
+scalaVersion:="2.11.7"
 
 scalacOptions ++= Seq(
   "-deprecation",
@@ -24,9 +24,9 @@ scalacOptions ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "io.spray" % "spray-client" % "1.3.1",
-  "io.spray" %%  "spray-json" % "1.2.6",
-  "com.typesafe.akka" %% "akka-actor" % "2.3.0",
+  "io.spray" %% "spray-client" % "1.3.2",
+  "io.spray" %%  "spray-json" % "1.3.0",
+  "com.typesafe.akka" %% "akka-actor" % "2.4.0",
   "org.scalacheck" %% "scalacheck" % "1.11.3" % "test"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ scalacOptions ++= Seq(
   "-language:existentials",
   "-language:higherKinds",
   "-language:implicitConversions",
-  "-target:jvm-1.7",
+  "-target:jvm-1.8",
   "-unchecked",
   "-Xfatal-warnings",
   "-Xlint",

--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,7 @@ import scalariform.formatter.preferences._
 
 
 name:="spray-cookies"
+organization:="de.postlab.from.martijnhoekstra"
 
 version:="0.1-SNAPSHOT"
 
@@ -30,6 +31,8 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-actor" % "2.4.0",
   "org.scalacheck" %% "scalacheck" % "1.11.3" % "test"
 )
+
+publishTo := Some(Resolver.file("file",  new File(Path.userHome.absolutePath+"/.m2/repository")))
 
 scalariformSettings
 

--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,7 @@ scalacOptions ++= Seq(
   "-language:existentials",
   "-language:higherKinds",
   "-language:implicitConversions",
+  "-target:jvm-1.7",
   "-unchecked",
   "-Xfatal-warnings",
   "-Xlint",

--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,7 @@ import scalariform.formatter.preferences._
 
 
 name:="spray-cookies"
-organization:="de.postlab.from.martijnhoekstra"
-
-version:="0.1-SNAPSHOT"
+organization:="net.spraycookies"
 
 scalaVersion:="2.11.7"
 
@@ -26,10 +24,10 @@ scalacOptions ++= Seq(
 )
 
 libraryDependencies ++= Seq(
-  "io.spray" %% "spray-client" % "1.3.2",
-  "io.spray" %%  "spray-json" % "1.3.0",
-  "com.typesafe.akka" %% "akka-actor" % "2.4.0",
-  "org.scalacheck" %% "scalacheck" % "1.11.3" % "test"
+  "io.spray"            %% "spray-client"  % "1.3.2",
+  "io.spray"            %% "spray-json"    % "1.3.0",
+  "com.typesafe.akka"   %% "akka-actor"    % "2.4.0",
+  "org.scalacheck"      %% "scalacheck"    % "1.11.3" % "test"
 )
 
 publishTo := Some(Resolver.file("file",  new File(Path.userHome.absolutePath+"/.m2/repository")))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,3 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
+
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.2")

--- a/src/main/scala/Cookiejar.scala
+++ b/src/main/scala/Cookiejar.scala
@@ -40,7 +40,11 @@ class CookieJar(blacklist: EffectiveTldList) {
      */
     private def extractDirectoryPath(uri: Uri): String = {
       val i = uri.path.toString.lastIndexOf("/")
-      uri.path.toString.substring(0, i + 1) // take the path
+      if (i > 0) {
+        uri.path.toString.substring(0, i) // take the path
+      } else {
+        "/"
+      }
     }
   }
 
@@ -67,6 +71,8 @@ class CookieJar(blacklist: EffectiveTldList) {
     } else false
   }
 
+  override def toString: String = data.toString
+
   private def isAllowedFor(cookie: StoredCookie, source: Uri): Boolean = {
     !blacklist.contains(cookie.domain) &&
       isDomainPostfix(cookie.domain, source.authority.host.address)
@@ -89,6 +95,14 @@ class CookieJar(blacklist: EffectiveTldList) {
    * @param cookies cookies set on this domain by name -> StoredCookie
    */
   private case class CookieJar_(domainElement: String, subdomains: Map[String, CookieJar_], cookies: Map[String, StoredCookie]) {
+
+    override def toString: String = {
+      "CookieJar{" +
+        cookies.map { case (name, cookie) ⇒ cookie }.mkString(", ") +
+        subdomains.map { case (name, subjar) ⇒ s"$name -> $subjar" }.mkString(", ") +
+        "}"
+    }
+
     def cookiesfor(uri: Uri) = {
       val domain = uri.authority.host.address
       val domainelements = domain.split('.').toList.reverse

--- a/src/test/scala/CookiePathSpecification.scala
+++ b/src/test/scala/CookiePathSpecification.scala
@@ -1,0 +1,71 @@
+import net.spraycookies.CookieJar
+import net.spraycookies.tldlist.DefaultEffectiveTldList
+import org.scalacheck.Prop.forAll
+import org.scalacheck._
+import spray.http.{ Uri, HttpCookie }
+
+object CookiePathSpecification extends Properties("CookiePathJuggling") {
+
+  val hostAndSchemeGen = Gen.oneOf("http://www1.example.com", "http://www2.example.com", "http://other.org", "http://www.something.net")
+
+  val someNameGen = Gen.identifier suchThat (s ⇒ (s.length < 500) && (s.length > 1)) // avoid URLs >1024 in total
+  val dirDepth = Gen.choose(0, 2)
+  val end: Gen[String] = Gen.oneOf("/", "")
+
+  // hints for smarter generation of this kind of data are welcome ;-)
+  val cookieGen = for {
+    host ← hostAndSchemeGen
+    dir ← someNameGen
+    subdir ← someNameGen
+    depth ← dirDepth
+    end ← end
+    name ← someNameGen
+    value ← someNameGen
+  } yield CookieContainer(host, depth, dir, subdir, end, name, value)
+
+  property("cookiesSetAndUsedForPath") = forAll(cookieGen) { url ⇒
+    {
+      val cookiejar = new CookieJar(DefaultEffectiveTldList)
+
+      cookiejar.setCookie(HttpCookie(url.name, url.value), url.toString)
+      val cookiesDirect = cookiejar.cookiesfor(Uri(url.toString))
+
+      val uri = Uri(url.toString)
+      val lastSep = uri.path.toString.lastIndexOf('/')
+      val shortPath = if (lastSep > 0) {
+        uri.path.toString.substring(0, lastSep)
+      } else {
+        "/"
+      }
+      val shortUri = uri.withPath(Uri(shortPath).path)
+      val cookiesShort = cookiejar.cookiesfor(shortUri)
+
+      if (cookiesDirect.size == 1 && cookiesShort.size == 1) {
+        true
+      } else {
+        println(url + "\t" + url.name + "\t" + url.value)
+        println("shortUrl: " + shortUri)
+        println("direct: " + cookiesDirect)
+        println("short: " + cookiesShort)
+        false
+      }
+    }
+  }
+
+}
+
+sealed case class CookieContainer(host: String, depth: Int, dir: String, subdir: String, end: String, name: String, value: String) {
+
+  override def toString = {
+    val sb = StringBuilder.newBuilder
+    sb.append(host + "/")
+    if (depth > 0) {
+      sb.append(dir)
+      if (depth > 1) {
+        sb.append("/" + subdir)
+      }
+      sb.append(end)
+    }
+    sb.toString
+  }
+}

--- a/src/test/scala/cookiejarSpecification.scala
+++ b/src/test/scala/cookiejarSpecification.scala
@@ -45,7 +45,7 @@ object CookiejarSpecification extends Properties("CookieHandling") {
 
       val addingPipeline = (req: HttpRequest) ⇒ {
         val resp = HttpResponse()
-        future {
+        Future {
           val setCookieHeaders = cookies.map(`Set-Cookie`(_))
           val cookiedresp = resp.withHeaders(setCookieHeaders)
           cookiedresp
@@ -53,7 +53,7 @@ object CookiejarSpecification extends Properties("CookieHandling") {
       }
 
       val testingPipeline = (req: HttpRequest) ⇒ {
-        future {
+        Future {
           val httpCookies = req.headers.collect({ case Cookie(httpCookies) ⇒ httpCookies }).flatten
           if (httpCookies.length > cookies.length) throw new Exception("received more cookies than expected")
           else if (!cookies.forall(expected ⇒ httpCookies.exists(received ⇒ received.name == expected.name))) throw new Exception("reponse didn't contain cookies for all names")

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "0.1-SNAPSHOT"


### PR DESCRIPTION
Hi Martin,

I'd like to use spray-cookies in a project for a client and therefore needed a recent version and a release of this. I did some minor housekeeping related to updating to Scala 2.11, added some comments and useful toString etc.

I fixed un unexpected behaviour with cookies that have no explicit path set and adapted the CookieJar to reflect my understand of the current RFC. This happens for example when using OAuth, where the url

> https://www.example.com/callback?querystring

will be called and expects the cookie to be set on `path /` even without an explicity path param in the Set-Cookie header. Since I needed the solution directly, I did not file an issue for that.

I need a released version of the lib in my project. Since you created that project, I wanted to give you the chance of taking my changes and of course to do the release. If not I'd likely create a release from my version. In any case, your feedback is highly appreciated.

Cheers
Michel
